### PR TITLE
chore: add root true

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
 module.exports = {
   extends: ['eslint-config-salesforce-typescript', 'plugin:sf-plugin/recommended'],
+  root: true,
 };


### PR DESCRIPTION
### What does this PR do?
Adds `root: true` to the base eslint config. This will stop eslint from continuing up the directory hierarchy for configs. This fixes a "bug" in `plugin-dev` tests.

> By default, ESLint looks for configuration files in all parent folders up to the root directory. This can be useful if you want all of your projects to follow a certain convention, but can sometimes lead to unexpected results. To limit ESLint to a specific project, place "root": true inside the .eslintrc.* file or eslintConfig field of the package.json file or in the .eslintrc.* file at your project’s root level. ESLint stops looking in parent folders once it finds a configuration with "root": true.

[Docs](https://eslint.org/docs/latest/use/configure/configuration-files#:~:text=By%20default%2C%20ESLint,root%22%3A%20true.)

### What issues does this PR fix or reference?
[@W-12987628@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12987628)