### PR TITLE
Add workflow token

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -17,7 +17,7 @@ jobs:
   release:
     uses: salesforcecli/github-workflows/.github/workflows/create-github-release.yml@main
     secrets:
-      SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.SF_CLI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+      SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
     with:
       prerelease: ${{ inputs.prerelease }}
       # If this is a push event, we want to skip the release if there are no semantic commits
@@ -29,6 +29,6 @@ jobs:
   #   # Depends on the 'release' job to avoid git collisions, not for any functionality reason
   #   needs: release
   #   secrets:
-  #     SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.SF_CLI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+  #     SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
   #   if: ${{ github.ref_name == 'main' }}
   #   uses: salesforcecli/github-workflows/.github/workflows/publishTypedoc.yml@main

--- a/.github/workflows/devScripts.yml
+++ b/.github/workflows/devScripts.yml
@@ -8,4 +8,4 @@ jobs:
   update:
     uses: salesforcecli/github-workflows/.github/workflows/devScriptsUpdate.yml@main
     secrets:
-      SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.SF_CLI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+      SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This change allow 3PP developers to utilize our shared github-workflows. 

I want to test if the default `GITHUB_TOKEN` will work for committing back to the repository

https://github.com/salesforcecli/github-workflows/pull/90
[@W-14809762@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14809762)
